### PR TITLE
[CL-00] fix: Fixes memory leak

### DIFF
--- a/server/loggerMiddleware.js
+++ b/server/loggerMiddleware.js
@@ -26,9 +26,11 @@ const loggerMiddleware = (req, res, next) => {
   const url = req.url;
   const referer = req.headers?.referer;
 
-  // Memory leak happens here
+  // Memory leak does NOT happens here
   req.logger = winston.createLogger({
-    ...loggerParams,
+    transports: [new winston.transports.Console({ level: "info" })],
+    format: winston.format.combine(winston.format.json()),
+    levels,
     defaultMeta: {
       url,
       referer,


### PR DESCRIPTION
### **Steps to test:**
- yarn build
- yarn start
- open `localhost:3000/status` This is where we'll check memory usage status for our server.
- Run this command `npx loadtest --rps 500 http://localhost:3000/ -t 60`. This basically hits our server with 500 requests a second for 60 seconds.




### **Case 1** : Reuse same transport Instances
When Load Test is Running
<img width="565" alt="image" src="https://github.com/tathagat2000/Winston-Memory-Leak/assets/44511377/d42051a6-4b98-48d9-b0da-2eb0fd454c9c">

2 minutes after load test has finished running
<img width="569" alt="image" src="https://github.com/tathagat2000/Winston-Memory-Leak/assets/44511377/1a7413c0-a76d-475d-9d23-18bb7c63c7ca">

Server Logs
<img width="864" alt="image" src="https://github.com/tathagat2000/Winston-Memory-Leak/assets/44511377/cbff7a90-8d26-48d5-8a27-0d16f9190dd0">


Inference : Memory and Heap usage spikes significantly when loadTesting is done, and even after it's over memory usage is persistent. Also note that the serverLogs indicate a possible memoryLeak.





### **Case 2** : Create new transport Instance
When Load Test Is Running
<img width="570" alt="image" src="https://github.com/tathagat2000/Winston-Memory-Leak/assets/44511377/69d3e8c8-8cca-4b42-8967-8ee175d7154b">

2 minutes after load test has finished running
<img width="576" alt="image" src="https://github.com/tathagat2000/Winston-Memory-Leak/assets/44511377/e995e87f-d4ca-461d-9084-775f5beac037">


Server Logs
<img width="863" alt="image" src="https://github.com/tathagat2000/Winston-Memory-Leak/assets/44511377/6ae5704f-e69f-4512-be33-9bb5cd5c9533">

Inference: Memory and Heap usage spikes here too, but even when loadTesting is running it spikes down which might indicate that garbage collection took place. It reduces significantly, and comes back to the starting point few seconds after load testing has finished. Also the serverLogs don't indicate any possible memoryLeak.


Reference
https://github.com/precisely/web/pull/368/files
https://github.com/winstonjs/winston/issues/2237
https://github.com/winstonjs/winston/issues/1334#issuecomment-392298414



Another thing that points to this memory leak, is below heap analysis.
<img width="1728" alt="image" src="https://github.com/tathagat2000/Winston-Memory-Leak/assets/44511377/0183180e-62f7-4792-a8a8-a1520440947d">

The Console Transport's Shallow Size is close to zero, but it's retained size is very very large. This indicates that because of this transport, all the winston logger instances are retained and haven't been garbage collected yet. This confirms the root cause of memory leak issue to be same reference of transport
